### PR TITLE
Add a link to the sample workshop metadata

### DIFF
--- a/info/metadata.yaml
+++ b/info/metadata.yaml
@@ -1,5 +1,7 @@
 title: Sample Workshop
 
+# For an example of all the available fields, please refer to https://github.com/hackersatcambridge/workshop-example/blob/master/info/metadata.yaml
+
 # People who have directly contributed content to this workhsop
 contributors:
   - Richard HaC


### PR DESCRIPTION
Done so that workshops created from this template can easily refer back to this.